### PR TITLE
Input field in overlay is now focused by default

### DIFF
--- a/GiphyPropertyEditor/App_Plugins/GiphyPropertyEditor/js/giphy.picker.controller.js
+++ b/GiphyPropertyEditor/App_Plugins/GiphyPropertyEditor/js/giphy.picker.controller.js
@@ -1,4 +1,9 @@
-﻿function giphyPickerController($scope, $http) {
+﻿function giphyPickerController($scope, $http, $element, $timeout) {
+
+    $timeout(function () {
+        var input = $element[0].querySelector("#giphy-search");
+        if (input) input.focus();
+    }, 20);
 
     $scope.submit = function (result) {
         if ($scope.model.submit) {


### PR DESCRIPTION
A little timeout is necessary to make sure Angular has loaded the various partials - otherwise `#giphy-search` won't be in the DOM yet. 20 ms seems sufficient, although I've only just tested it quickly on my machine. 